### PR TITLE
New docsy theme requires Hugo Extended edition

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,8 @@ jobs:
       - name: Hugo Deploy GitHub Pages
         uses: benmatselby/hugo-deploy-gh-pages@master
         env:
-          HUGO_VERSION: 0.73.0
+          HUGO_VERSION: 0.74.3
+          HUGO_EXTENDED: true
           TARGET_REPO: FSHSchool/FSHSchool.github.io
           TOKEN: ${{ secrets.TOKEN }}
           CNAME: fshschool.org


### PR DESCRIPTION
The GH Action failed to build the site.  I think it is because docsy requires the Hugo _extended_ edition. I also updated the Hugo version while I was in the config already.