### PR TITLE
GH Action: Install node modules locally (3rd time's a charm?)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,7 +20,7 @@ jobs:
           node-version: 12.x
 
       - name: Install docsy prerequisites
-        run: npm install -g postcss-cli autoprefixer
+        run: npm install postcss-cli autoprefixer
 
       - name: Hugo Deploy GitHub Pages
         uses: benmatselby/hugo-deploy-gh-pages@master


### PR DESCRIPTION
GH Action is still failing w/ installing node modules globally.  Hoping local install will do the trick!