### PR TITLE
Do not use --minify in CI as it adversely affects output

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: recursive 
+          submodules: recursive
           fetch-depth: 0
 
       - name: Setup Hugo
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - run: npm ci
-      - run: hugo --minify
+      - run: hugo
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
For example, on the community page, it deletes the spaces between the icons and the labels.

Without `--minify`:
<img width="617" alt="image" src="https://user-images.githubusercontent.com/2278253/88720123-59793480-d0f2-11ea-962f-30d384cd03b5.png">

With `--minify`:
<img width="609" alt="image" src="https://user-images.githubusercontent.com/2278253/88720056-41a1b080-d0f2-11ea-906c-8902af9f0042.png">
