### PR TITLE
Fix broken link in Basic Tutorial

### DIFF
--- a/content/docs/Tutorials/basic/_index.md
+++ b/content/docs/Tutorials/basic/_index.md
@@ -11,7 +11,7 @@ resources:
 
 ### Step 1: Review Getting Started
 
-If you haven't done so already, please read or review the [Getting Started](/getting-started/) documentation to gain an understanding of the conventions used in this tutorial and the resources available to you.
+If you haven't done so already, please read or review the [Getting Started](/docs/getting-started/) documentation to gain an understanding of the conventions used in this tutorial and the resources available to you.
 
 ### Step 2: Install Node.js and Sushi
 

--- a/content/docs/Tutorials/basic/_index.md
+++ b/content/docs/Tutorials/basic/_index.md
@@ -15,7 +15,7 @@ If you haven't done so already, please read or review the [Getting Started](/doc
 
 ### Step 2: Install Node.js and Sushi
 
-If you have not already installed SUSHI, follow the [SUSHI Installation](/sushi/installation) instructions.
+If you have not already installed SUSHI, follow the [SUSHI Installation](/docs/sushi/installation) instructions.
 
 ### Step 3: Download Sample FSH Tank
 


### PR DESCRIPTION
The link to the "Getting Started" page was a 404 because the path was wrong.

Same problem with the link to "SUSHI Installation", which I also fixed.