### PR TITLE
Fix broken internal links

### DIFF
--- a/content/docs/SUSHI/project/_index.md
+++ b/content/docs/SUSHI/project/_index.md
@@ -15,7 +15,7 @@ simple-project
 └── file3.fsh
 ```
 
-The **config.yaml** file provides project configuration data to SUSHI. It is described further in the [Configuration](/sushi/configuration/) documentation.
+The **config.yaml** file provides project configuration data to SUSHI. It is described further in the [Configuration](/docs/sushi/configuration/) documentation.
 
 Each FSH file can contain multiple FSH definitions of varying types. FSH file names are not significant, but must end with the **.fsh** extension. In addition, FSH files can be organized into subdirectories. This provides authors the flexibility to organize their FSH definitions in whatever way makes sense to then.
 
@@ -77,7 +77,7 @@ customized-ig
 
 You can populate your project (under **fsh** above) as follows:
 
-* **config.yaml**: This required file provides project configuration data to SUSHI. It is described further in the [Configuration](/sushi/configuration/) documentation.
+* **config.yaml**: This required file provides project configuration data to SUSHI. It is described further in the [Configuration](/docs/sushi/configuration/) documentation.
 * **\*.fsh**: FSH files contain the FHIR Shorthand definitions for all the resources and examples in your IG.
 * **ig-data/ig.ini**: If present and no `template` property is specified in **config.yaml**, the user-provided file will be used instead of a generated one.
 * **ig-data/input/ignoreWarnings.txt**: If present, this file can be used to suppress specific QA warnings and information messages during the FHIR IG publication process.

--- a/content/docs/SUSHI/running/_index.md
+++ b/content/docs/SUSHI/running/_index.md
@@ -60,13 +60,13 @@ Here are some general tips for debugging:
 * **Parsing (syntax) errors should be fixed first.** A single syntax error can ballooon into many other errors, so you should always eliminate syntax errors first. Syntax error messages may include `extraneous input {x} expecting {y}`, `mismatched input {x} expecting {y}` and `no viable alternative at {x}`. These messages indicate that the line in question is not a valid FSH statement.
 * **The order of keywords matters.** The declarations must start with the type of item you are creating (e.g., Profile, Instance, ValueSet).
 * **The order of rules usually doesn't matter, but there are exceptions.** Slices and extensions must be created before they are constrained.
-* **Rules must contain valid paths.** The `No element found at path` error means that although the overall grammar of the rule may be correct, SUSHI could not find the FHIR element you are referring to in the rule. Make sure there are no spelling errors, the element names in the path are correct, and you are using the [path grammar]([reference.html#fsh-paths](https://build.fhir.org/ig/HL7/fhir-shorthand/reference.html#fsh-paths)) correctly.
+* **Rules must contain valid paths.** The `No element found at path` error means that although the overall grammar of the rule may be correct, SUSHI could not find the FHIR element you are referring to in the rule. Make sure there are no spelling errors, the element names in the path are correct, and you are using the [path grammar](https://build.fhir.org/ig/HL7/fhir-shorthand/reference.html#fsh-paths) correctly.
 * **The community can help.** If you are getting an error you can't resolve, you can ask for help on the [#shorthand chat channel](https://chat.fhir.org/#narrow/stream/215610-shorthand).
 
 
 ## SUSHI Outputs
 
-Based on the inputs in FSH files, **config.yaml**, and the **ig-data** directory, SUSHI populates the output directory. For example, the customized-ig project from the [Project Structure](/sushi/project/) section would result in output like the following:
+Based on the inputs in FSH files, **config.yaml**, and the **ig-data** directory, SUSHI populates the output directory. For example, the customized-ig project from the [Project Structure](/docs/sushi/project/) section would result in output like the following:
 
 ```text
 customized-ig

--- a/content/docs/Tutorials/basic/_index.md
+++ b/content/docs/Tutorials/basic/_index.md
@@ -7,7 +7,7 @@ resources:
   title: FSH Tutorial Starter
 ---
 
-[FHIR Shorthand](reference.html) (FSH) is a specially-designed language for defining the content of FHIR Implementation Guides (IGs). It is simple and compact, with tools to produce Fast Healthcare Interoperability Resources (FHIR) profiles, extensions and IGs. FSH is compiled from text files to FHIR artifacts using [SUSHI](sushi.html). To get started using FSH, you need to install and run SUSHI using the steps below.
+[FHIR Shorthand](/about) (FSH) is a specially-designed language for defining the content of FHIR Implementation Guides (IGs). It is simple and compact, with tools to produce Fast Healthcare Interoperability Resources (FHIR) profiles, extensions and IGs. FSH is compiled from text files to FHIR artifacts using [SUSHI](/docs/sushi). To get started using FSH, you need to install and run SUSHI using the steps below.
 
 ### Step 1: Review Getting Started
 

--- a/content/docs/getting-started/_index.md
+++ b/content/docs/getting-started/_index.md
@@ -5,7 +5,7 @@ weight: 5
 
 [FHIR Shorthand](https://build.fhir.org/ig/HL7/fhir-shorthand/reference.html) ("FSH" or "Shorthand") is a specially-designed language for defining the content of Health Level Seven (HL7®) [Fast Healthcare Interoperability Resources (FHIR®)](https://www.hl7.org/fhir/R4/overview.html) Implementation Guides (IGs). It is simple and compact, with tools to produce Fast Healthcare Interoperability Resources (FHIR) profiles, extensions and IGs.
 
-[SUSHI](/sushi/) ("SUSHI Unshortens ShortHand Inputs") is a reference implementation of an interpreter/compiler for the FSH language. SUSHI produces FHIR profiles, extensions, and other artifacts needed to create FHIR Implementation Guides (IG).
+[SUSHI](/docs/sushi/) ("SUSHI Unshortens ShortHand Inputs") is a reference implementation of an interpreter/compiler for the FSH language. SUSHI produces FHIR profiles, extensions, and other artifacts needed to create FHIR Implementation Guides (IG).
 
 ## FSH School Conventions
 


### PR DESCRIPTION
There were several internal links that were broken after the move to the Docsy theme. Thanks to @masnick for noticing a few of these broken links in #10 and alerting us to this issue.