### PR TITLE
Make link to FSHOnline live

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -9,7 +9,7 @@ linkTitle = "FSH School"
 	<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "/docs" >}}">
 		Learn More <i class="fas fa-fish ml-2"></i>
 	</a>
-	<a class="btn btn-lg btn-secondary mr-3 mb-4" target="_blank" href="/coming-soon">
+	<a class="btn btn-lg btn-secondary mr-3 mb-4" target="_blank" href="/FSHOnline/">
 		Experiment <i class="fas fa-flask "></i>
 	</a>
 	<p class="lead mt-5">The place to learn and try FHIR Shorthand</p>


### PR DESCRIPTION
This makes the link for FSHOnline live. I'm not actually sure how to test that this is working locally, but given that https://fshschool.org/FSHOnline/ is live and working, I think this should work.