### PR TITLE
Document fsh.ini and update migration docs

### DIFF
--- a/content/docs-legacy/SUSHI/running/_index.md
+++ b/content/docs-legacy/SUSHI/running/_index.md
@@ -152,3 +152,12 @@ After the IG Publisher has been successfully downloaded, execute the following c
 ```
 
 This will run the HL7 IG Publisher, which may take several minutes to complete. After the publisher is finished, open the file **/output/index.html** in a browser to see the resulting IG.
+
+{{% alert title="Tip" color="success" %}}
+When running SUSHI, the IG Publisher will look for an optional **fsh.ini** control file in the root directory of the project (the same directory that contains **ig.ini**). This file should have `[FSH]` on the first line, and can include a `sushi-version` property, used to specify which version of SUSHI the IG Publisher should use, and a `timeout` property, used to set a timeout for SUSHI (in seconds). The default timeout is 60 seconds. An example **fsh.ini** file is provided below.
+```text
+[FSH]
+sushi-version = 0.16.0
+timeout = 120
+```
+{{% /alert %}}

--- a/content/docs/SUSHI/migration/_index.md
+++ b/content/docs/SUSHI/migration/_index.md
@@ -58,16 +58,18 @@ Move the **./input/fsh/config.yaml** file to the top-level folder, and rename it
 
 You can now run SUSHI 1.0. You may get further instructions in the form of error messages.
 
-One error message concerns the `template` property in **sushi-config.yaml**. If you get that error, follow the instructions to remove that property from **sushi-config.yaml** and create an **./ig.ini** file.
+One error message concerns the `template` property in **sushi-config.yaml**. If you get that error, follow the instructions to remove that property from **sushi-config.yaml** and create an **./ig.ini** file. 
 
 {{% alert title="Warning" color="warning" %}}
-You must specify a template based on `fhir.base.template#current`. Older templates will not work with SUSHI 1.0. Any of the following should work:
+**Carefully consider the contents of ig.ini**. You must specify a `template` property based on `fhir.base.template#current`. Older templates will not work with SUSHI 1.0. Any of the following should work:
 
   * `template = fhir.base.template#current`
   * `template = hl7.base.template#current`
   * `template = hl7.fhir.template#current`
   * `template = hl7.davinci.template#current`
   * `template = hl7.cda.template#current`
+
+The `ig` property must point to an ImplementationGuide resource. If SUSHI is generating your ImplementationGuide resource, it will be generated to **fsh-generated/resources/ImplementationGuide-{ig-id}.json**.
 {{% /alert %}}
 
 Another error message you might receive concerns the `history` property in **sushi-config.yaml**. If you get that message, remove that property and create the **package-list.json** file as instructed.

--- a/content/docs/SUSHI/running/_index.md
+++ b/content/docs/SUSHI/running/_index.md
@@ -147,3 +147,12 @@ After the IG Publisher has been successfully downloaded, execute the following c
 ```
 
 This will run the HL7 IG Publisher, which may take several minutes to complete. After the publisher is finished, open the file **/output/index.html** in a browser to see the resulting IG.
+
+{{% alert title="Tip" color="success" %}}
+When running SUSHI, the IG Publisher will look for an optional **fsh.ini** control file in the root directory of the project (the same directory that contains **ig.ini**). This file should have `[FSH]` on the first line, and can include a `sushi-version` property, used to specify which version of SUSHI the IG Publisher should use, and a `timeout` property, used to set a timeout for SUSHI (in seconds). The default timeout is 60 seconds. An example **fsh.ini** file is provided below.
+```text
+[FSH]
+sushi-version = 0.16.0
+timeout = 120
+```
+{{% /alert %}}


### PR DESCRIPTION
This fixes https://github.com/FHIR/sushi/issues/668 by adding a description of the `ig` property in `ig.ini` to the migration documentation. It also adds documentation on the optional `fsh.ini` file that the IG Publisher now supports.