### PR TITLE
Add applyExtensionMetadataToRoot config option

### DIFF
--- a/content/docs/SUSHI/configuration/_index.md
+++ b/content/docs/SUSHI/configuration/_index.md
@@ -128,6 +128,7 @@ The table below lists all configuration properties that can be used in SUSHI's *
 | canonical | N/A | The canonical URL to be used throughout the IG |
 | menu | N/A | Used to generate the `fsh-generated/includes/menu.xml` file. The key is the menu item name and the value is the URL. Menus can contain sub-menus, but the IG Publisher currently only supports sub-menus one level deep. <br><br> Authors can provide their own `menu.xml` by removing this property and placing a `menu.xml` file in `/input/includes` |
 | FSHOnly | N/A | When this flag is set to `true`, no IG specific content will be generated, SUSHI will only convert FSH definitions to JSON files. When false or unset, IG content is generated.
+| applyExtensionMetadataToRoot | N/A | When set to true, the "short" and "definition" field on the root element of an Extension will be set to the "Title" and "Description" of that Extension. Default is true.
 
 ## Exhaustive Example
 

--- a/content/docs/SUSHI/configuration/exhaustive-config.yaml
+++ b/content/docs/SUSHI/configuration/exhaustive-config.yaml
@@ -178,3 +178,7 @@ parameters:
 # If set to true, no IG related content will be generated.
 # The default value for this property is false.
 FSHOnly: false
+
+# When set to true, the "short" and "definition" field on the root element of an Extension will
+# be set to the "Title" and "Description" of that Extension. Default is true.
+applyExtensionMetadataToRoot: false


### PR DESCRIPTION
This adds description of the `applyExtensionMetadataToRoot` configuration option that is added in this PR: https://github.com/FHIR/sushi/pull/719.

Note that this PR is a draft, since it should not be merged until a version of SUSHI is released that contains the `applyExtensionMetadataToRoot` flag.