### PR TITLE
Update Documentation for GoFSH 1.0

### DIFF
--- a/content/docs/SUSHI/API/_index.md
+++ b/content/docs/SUSHI/API/_index.md
@@ -17,7 +17,7 @@ fshToFhir(fshString[, options])
 * `canonical` - A string used to specify the canonical URL.
 * `version` - A string used to specify the version.
 * `fhirVersion` - A string used to specify the version of FHIR to use.
-* `dependencies` - An array of objects used to specify dependencies required for processing the FSH. Each object can have a `uri`, `packageId`, or `version`.
+* `dependencies` - An array of objects used to specify dependencies required for processing the FSH. Each object should have a `packageId` and `version`, and optionally a `uri`.
 * `logLevel` - A string that specifies what level of logging to use when processing FSH. Options are `silent`, `debug`, `info`, `warn`, and `error`.
 
 
@@ -26,8 +26,8 @@ See the [configuration](/docs/sushi/configuration/#full-configuration) documenta
 ## Return Value
 An object with the following attributes:
 * `fhir` - An array of FHIR definitions generated from the input FSH.
-* `errors` - An array containing any errors detected during processing.
-* `warnings` - An array containing any warnings detected during processing.
+* `errors` - An array of strings containing any errors detected during processing.
+* `warnings` - An array of strings containing any warnings detected during processing.
 
 ## Usage
 To use `fshToFhir`, you must first install `fsh-sushi` as a dependency of your project:
@@ -39,6 +39,17 @@ Once `fsh-sushi` is installed as a dependency of your project, you can `import` 
 ```javascript
 import { sushiClient } from 'fsh-sushi';
 
+// Example basic usage
 sushiClient.fshToFhir('Your FSH here');
+
+// Example usage with options
+sushiClient.fshToFhir(
+  'Your FSH here',
+  {
+    canonical: 'http://example.com',
+    version: '1.2.3',
+    dependencies: [{ packageId: 'hl7.fhir.us.core', version: '3.1.0' }],
+    logLevel: 'error'
+  });
 ```
 

--- a/content/docs/SUSHI/API/_index.md
+++ b/content/docs/SUSHI/API/_index.md
@@ -16,7 +16,7 @@ fshToFhir(fshString[, options])
 `options` - An object which can have any combination of the following attributes:
 * `canonical` - A string used to specify the canonical URL.
 * `version` - A string used to specify the version.
-* `fhirVersion` - A string used to specify the version of FHIR to use.
+* `fhirVersion` - A string used to specify the version of FHIR to use. Note that SUSHI only supports FHIR R4 and R5.
 * `dependencies` - An array of objects used to specify dependencies required for processing the FSH. Each object should have a `packageId` and `version`, and optionally a `uri`.
 * `logLevel` - A string that specifies what level of logging to use when processing FSH. Options are `silent`, `debug`, `info`, `warn`, and `error`.
 
@@ -48,6 +48,7 @@ sushiClient.fshToFhir(
   {
     canonical: 'http://example.com',
     version: '1.2.3',
+    fhirVersion: '4.0.1',
     dependencies: [{ packageId: 'hl7.fhir.us.core', version: '3.1.0' }],
     logLevel: 'error'
   });

--- a/content/docs/SUSHI/API/_index.md
+++ b/content/docs/SUSHI/API/_index.md
@@ -1,0 +1,44 @@
+---
+title: "API"
+weight: 25
+---
+
+SUSHI exposes a `fshToFhir` function that can be used to convert FSH strings to FHIR JSON.
+
+## Syntax
+```javascript
+fshToFhir(fshString[, options])
+```
+
+## Parameters
+`fshString` - A string containing FHIR Shorthand definitions.
+
+`options` - An object which can have any combination of the following attributes:
+* `canonical` - A string used to specify the canonical URL.
+* `version` - A string used to specify the version.
+* `fhirVersion` - A string used to specify the version of FHIR to use.
+* `dependencies` - An array of objects used to specify dependencies required for processing the FSH. Each object can have a `uri`, `packageId`, or `version`.
+* `logLevel` - A string that specifies what level of logging to use when processing FSH. Options are `silent`, `debug`, `info`, `warn`, and `error`.
+
+
+See the [configuration](/docs/sushi/configuration/#full-configuration) documentation for more information on `canonical`, `version`, `fhirVersion`, and `dependencies`. These properties correspond to the properties of the same name that are used in `sushi-config.yaml`.
+
+## Return Value
+An object with the following attributes:
+* `fhir` - An array of FHIR definitions generated from the input FSH.
+* `errors` - An array containing any errors detected during processing.
+* `warnings` - An array containing any warnings detected during processing.
+
+## Usage
+To use `fshToFhir`, you must first install `fsh-sushi` as a dependency of your project:
+```shell
+{{< terminal >}} npm install fsh-sushi
+```
+Once `fsh-sushi` is installed as a dependency of your project, you can `import` and use this function as shown:
+
+```javascript
+import { sushiClient } from 'fsh-sushi';
+
+sushiClient.fshToFhir('Your FSH here');
+```
+

--- a/content/docs/Tutorials/goFSH/_index.md
+++ b/content/docs/Tutorials/goFSH/_index.md
@@ -21,7 +21,7 @@ After the file is unzipped, you should see two FHIR artifacts:
 * **StructureDefinition-mcode-genetic-specimen.json**
 * **StructureDefinition-mcode-laterality.json**
 
-### Step 4: Run GoFSH
+### Step 2: Run GoFSH
 
 Now that you have GoFSH installed and sample FHIR artifacts, open up a command window, and navigate to the directory containing the artifacts you downloaded. Run GoFSH on those files by executing:
 
@@ -33,25 +33,17 @@ Now that you have GoFSH installed and sample FHIR artifacts, open up a command w
 The dot (.) represents "this directory," the location of the files. You can also specify the location explicitly by replacing the dot with a directory path.
 {{% /alert %}}
 
-Running GoFSH will create a **fsh/** directory, and populate it with **resources.fsh**, a file containing the FSH definitions corresponding to the input files. If you open up **resources.fsh**, you should see two FSH definitions, a `Profile` called "GeneticSpecimen", and an `Extension` called "Laterality".
+Running GoFSH will create a **gofsh/** directory, and populate it with **input/fsh/resources.fsh**, a file containing the FSH definitions corresponding to the input files. If you open up **resources.fsh**, you should see two FSH definitions, a `Profile` called "GeneticSpecimen", and an `Extension` called "Laterality".
 
-{{% alert title="Note" color="primary" %}}
-The current pre-release of GoFSH does not always produce the most efficient FSH representation possible. For example, the `Laterality` extension produced by GoFSH contains slicing directives that are not strictly necessary, as this slicing is inferred when the `valueCodeableConcept` path is used in a rule. While the explicit slicing directives are not incorrect, future versions of GoFSH will recognize them as redundant and omit them.
-{{% /alert %}}
-
-### Step 5: Run SUSHI (Optional)
+### Step 3: Run SUSHI (Optional)
 
 Now that you have generated FSH definitions, you can run SUSHI on those definitions to recreate your original input to GoFSH. First, ensure you have [SUSHI installed](/docs/sushi/installation), then download the **sushi-config.yaml** file given below:
 {{% show-file src="config" download="bottom" %}}
 
-and place that file into the **fsh/** output directory that was created by GoFSH. Then, navigate the command line to the **fsh/** directory, and run:
+and place that file into the **gofsh/** output directory that was created by GoFSH. Then, navigate the command line to the **gofsh/** directory, and run:
 
 ```shell
 {{< terminal >}} sushi .
 ```
 
-This command will run SUSHI on **resources.fsh**, and generate the output of that FSH into a directory called **build/input/profiles**. You can then compare the output from running GoFSH and then SUSHI to the original **StructureDefinition-mcode-genetic-specimen.json** and **StructureDefinition-mcode-laterality.json** files.
-
-{{% alert title="Note" color="primary" %}}
-Newer versions of SUSHI (>= 1.0.0) may emit warnings related to project structure. The process of aligning GoFSH output with SUSHI input is ongoing, and for now those warnings can be safely ignored.
-{{% /alert %}}
+This command will run SUSHI on **input/fsh/resources.fsh**, and generate the output of that FSH into a directory called **build/input/profiles**. You can then compare the output from running GoFSH and then SUSHI to the original **StructureDefinition-mcode-genetic-specimen.json** and **StructureDefinition-mcode-laterality.json** files.

--- a/content/docs/Tutorials/goFSH/_index.md
+++ b/content/docs/Tutorials/goFSH/_index.md
@@ -33,17 +33,20 @@ Now that you have GoFSH installed and sample FHIR artifacts, open up a command w
 The dot (.) represents "this directory," the location of the files. You can also specify the location explicitly by replacing the dot with a directory path.
 {{% /alert %}}
 
-Running GoFSH will create a **gofsh/** directory, and populate it with **input/fsh/resources.fsh**, a file containing the FSH definitions corresponding to the input files. If you open up **resources.fsh**, you should see two FSH definitions, a `Profile` called "GeneticSpecimen", and an `Extension` called "Laterality".
+Running GoFSH will create a **gofsh** directory, and populate it with **input/fsh**, a directory containing several FSH files which define the original input files. If you open up **profiles.fsh**, you should see a FSH definition for a `Profile` called "GeneticSpecimen", and if you open up **extensions.fsh**, you should see an `Extension` called "Laterality".
 
 ### Step 3: Run SUSHI (Optional)
 
-Now that you have generated FSH definitions, you can run SUSHI on those definitions to recreate your original input to GoFSH. First, ensure you have [SUSHI installed](/docs/sushi/installation), then download the **sushi-config.yaml** file given below:
-{{% show-file src="config" download="bottom" %}}
-
-and place that file into the **gofsh/** output directory that was created by GoFSH. Then, navigate the command line to the **gofsh/** directory, and run:
+Now that you have generated FSH definitions, you can run SUSHI on those definitions to recreate your original input to GoFSH. First, ensure you have [SUSHI installed](/docs/sushi/installation). Then, navigate the command line to the **gofsh/** directory, and run:
 
 ```shell
 {{< terminal >}} sushi .
 ```
 
-This command will run SUSHI on **input/fsh/resources.fsh**, and generate the output of that FSH into a directory called **build/input/profiles**. You can then compare the output from running GoFSH and then SUSHI to the original **StructureDefinition-mcode-genetic-specimen.json** and **StructureDefinition-mcode-laterality.json** files.
+This command will run SUSHI on the contents of **input/fsh**, and generate the output of that FSH into a directory called **fsh-generated/resources**. You can then compare the output from running GoFSH and then SUSHI to the original **StructureDefinition-mcode-genetic-specimen.json** and **StructureDefinition-mcode-laterality.json** files.
+
+Alternatively, you can automatically run SUSHI on the output of GoFSH using the `-f` [option](/docs/gofsh/running/#fshing-trip). The following command:
+```shell
+{{< terminal >}} gofsh . -f
+```
+will run SUSHI on the output of GoFSH, and generate a comparison file in **gofsh/fshing-trip-comparison.html** which displays differences between the original input, and the output of SUSHI.

--- a/content/docs/goFSH/API/_index.md
+++ b/content/docs/goFSH/API/_index.md
@@ -1,0 +1,57 @@
+---
+title: "API"
+weight: 25
+---
+
+GoFSH exposes a `fhirToFsh` function that can be used to convert FHIR to FSH.
+
+## Syntax
+```javascript
+fhirToFsh(fhir[, options])
+```
+
+## Parameters
+`fhir` - An array of FHIR resources, represented either as strings or JSON.
+
+`options` - An object which can have any combindation of the following attributes:
+* `dependencies` - An array of strings used to specify dependencies required for processing the FHIR. Dependencies should use the format `<packageId>#<version>` (example: `hl7.fhir.us.core#3.0.1`).
+* `logLevel` - A string that specifies what level of logging to use when processing FHIR. Options are `silent`, `debug`, `info`, `warn`, and `error`.
+* `style` - A string representing how the returned output is styled. The options are:
+  * `string` - The generated FSH will be returned in one single string. This is the default.
+  * `map` - The generated FSH will be returned as an object. The attributes on the object are:
+    * `aliases` - A string containing all `Alias` definitions.
+    * `profiles` - A `Map` containing all `Profile` definitions as values.
+    * `extensions` - A `Map` containing all `Extension` definitions as values.
+    * `codeSystems` - A `Map` containing all `CodeSystem` definitions as values.
+    * `valueSets` - A `Map` containing all `ValueSet` definitions as values.
+    * `instances` - A `Map` containing all `Instance` definitions as values.
+    * `invariants` - A `Map` containing all `Invariant` definitions as values.
+    * `mappings` - A `Map` containing all `Mapping` definitions as values.
+    
+    For each `Map`, the keys are the name of the FSH definition. For example, if the definition was:
+    ```
+    Profile: MyPatient
+    Parent: Patient
+    ```
+    The key would be `MyPatient`.
+
+## Return Value
+An object with the following attributes:
+* `fsh` - The generated FSH, styled according to the `style` parameter.
+* `configuration` - An object representing the `sushi-config.yaml` file that would be generated if GoFSH was running in a command line interface.
+* `errors` - An array containing any errors detected during processing.
+* `warnings` - An array containing any warnings detected during processing.
+
+## Usage
+To use `fhirToFsh`, you must first install `gofsh` as a dependency of your project:
+```shell
+{{< terminal >}} npm install gofsh
+```
+Once `gofsh` is installed as a dependency of your project, you can `import` and use this function as shown:
+
+```javascript
+import { gofshClient } from 'gofsh';
+
+gofshClient.fhirToFsh(['Your FHIR here']);
+```
+

--- a/content/docs/goFSH/API/_index.md
+++ b/content/docs/goFSH/API/_index.md
@@ -14,7 +14,7 @@ fhirToFsh(fhir[, options])
 `fhir` - An array of FHIR resources, represented either as strings or JSON.
 
 `options` - An object which can have any combindation of the following attributes:
-* `dependencies` - An array of strings used to specify dependencies required for processing the FHIR. Dependencies should use the format `<packageId>#<version>` (example: `hl7.fhir.us.core#3.0.1`).
+* `dependencies` - An array of strings used to specify dependencies required for processing the FHIR. Dependencies should use the format `<packageId>@<version>` (example: `hl7.fhir.us.core@3.0.1`).
 * `logLevel` - A string that specifies what level of logging to use when processing FHIR. Options are `silent`, `debug`, `info`, `warn`, and `error`.
 * `style` - A string representing how the returned output is styled. The options are:
   * `string` - The generated FSH will be returned in one single string. This is the default.
@@ -39,8 +39,8 @@ fhirToFsh(fhir[, options])
 An object with the following attributes:
 * `fsh` - The generated FSH, styled according to the `style` parameter.
 * `configuration` - An object representing the `sushi-config.yaml` file that would be generated if GoFSH was running in a command line interface.
-* `errors` - An array containing any errors detected during processing.
-* `warnings` - An array containing any warnings detected during processing.
+* `errors` - An array of strings containing any errors detected during processing.
+* `warnings` - An array of strings containing any warnings detected during processing.
 
 ## Usage
 To use `fhirToFsh`, you must first install `gofsh` as a dependency of your project:
@@ -52,6 +52,16 @@ Once `gofsh` is installed as a dependency of your project, you can `import` and 
 ```javascript
 import { gofshClient } from 'gofsh';
 
+// Example basic usage
 gofshClient.fhirToFsh(['Your FHIR here']);
+
+// Example usage with options
+gofshClient.fhirToFsh(
+  ['Your FHIR here'], 
+  {
+    dependencies: ["hl7.fhir.us.mcode@1.0.0"],
+    style: "map",
+    logLevel: "silent"
+  });
 ```
 

--- a/content/docs/goFSH/_index.md
+++ b/content/docs/goFSH/_index.md
@@ -3,10 +3,6 @@ title: "GoFSH"
 weight: 12
 ---
 
-This section contains documentation for GoFSH, which turns FHIR artifacts into FSH definitions. Using GoFSH, you can turn an existing FHIR Implementation Guide into a FSH project automatically. 
+This section contains documentation for GoFSH, which turns FHIR artifacts into FSH definitions. Using GoFSH, you can turn an existing FHIR Implementation Guide into a FSH project automatically.
 
 If you are starting a project from scratch, see [Initializing a SUSHI Project](/docs/sushi/project/#initializing-a-sushi-project).
-
-{{% alert title="Warning" color="warning" %}}
-GoFSH is currently in pre-release. See the [release notes](https://github.com/FHIR/GoFSH/releases) for features and limitations in the latest version.
-{{% /alert %}}

--- a/content/docs/goFSH/installation/_index.md
+++ b/content/docs/goFSH/installation/_index.md
@@ -36,9 +36,6 @@ Use `gofsh -v` to display the installed version of GoFSH and the version of the 
 * **MINOR**: Contains new or modified features, while maintaining backwards compatibility within the major version.
 * **PATCH**: Contains minor updates and bug fixes, while maintaining backwards compatibility within the major version.
 
-{{% alert title="Warning" color="warning" %}}
-Releases prior to 1.0.0 are considered pre-releases, and may introduce breaking changes in minor version increments.
-{{% /alert %}}
 
 ## Updating or Reverting GoFSH
 

--- a/content/docs/goFSH/running/_index.md
+++ b/content/docs/goFSH/running/_index.md
@@ -20,6 +20,7 @@ where options include the following (in any order):
 -v, --version                     print goFSH version
 -s, --style                       specify how the output is organized into files: group-by-fsh-type (default), group-by-profile, single-file, file-per-definition
 -f, --fshing-trip                 run SUSHI on the output of GoFSH and generate a comparison of the round trip results
+-t, --file-type                   specify which file types GoFSH should accept as input: json-only (default), xml-only, json-and-xml
 -i, --installed-sushi             use the locally installed version of SUSHI when generating comparisons with the "-f" option
 -h, --help                        output usage information
 ```

--- a/content/docs/goFSH/running/_index.md
+++ b/content/docs/goFSH/running/_index.md
@@ -34,7 +34,7 @@ The `style` option has four values:
 * `file-per-definition`: Each standalone FSH definition is written to an individual file. Only Aliases are combined into one `aliases.fsh` file.
 
 ### `fshing-trip`
-If this flag is added, after GoFSH runs, SUSHI will run on the output of GoFSH. The output of SUSHI will then be compared to the original input to GoFSH (FHIR is compared to FHIR), and a visualization of differences between the original input and the SUSHI output will be created in `<output-folder>/fshing-trip-comparison.html`. If the `--installed-sushi` flag is set, then this process will use whichever version of SUSHI you have globally installed. Otherwise GoFSH will use SUSHI version 1.1.0.
+If this flag is added, after GoFSH runs, SUSHI will run on the output of GoFSH. The output of SUSHI will then be compared to the original input to GoFSH (FHIR is compared to FHIR), and a visualization of differences between the original input and the SUSHI output will be created in `<output-folder>/fshing-trip-comparison.html`. If the `--installed-sushi` flag is set, then this process will use whichever version of SUSHI you have globally installed. Otherwise GoFSH will use its own built-in version of SUSHI (which may not be the latest version available).
 
 ## GoFSH Inputs
 
@@ -49,11 +49,6 @@ GoFSH does not require any configuration, but if the input FHIR artifacts depend
 {{% alert title="Info" color="info" %}}
 GoFSH can still generate FSH when dependencies are omitted, but the resulting FSH will be incomplete.
 {{% /alert %}}
-
-{{% alert title="Warning" color="warning" %}}
-GoFSH cannot generate FSH from XML inputs, only JSON is allowed.
-{{% /alert %}}
-
 
 ## GoFSH Outputs
 

--- a/content/docs/goFSH/running/_index.md
+++ b/content/docs/goFSH/running/_index.md
@@ -18,18 +18,28 @@ where options include the following (in any order):
 -l, --log-level <level>           specify the level of log messages: error, warn, info (default), debug
 -d, --dependency <dependency...>  specify dependencies to be loaded using format dependencyId@version (FHIR R4 included by default)
 -v, --version                     print goFSH version
+-s, --style                       specify how the output is organized into files: group-by-fsh-type (default), group-by-profile, single-file, file-per-definition
+-f, --fshing-trip                 run SUSHI on the output of GoFSH and generate a comparison of the round trip results
+-i, --installed-sushi             use the locally installed version of SUSHI when generating comparisons with the "-f" option
 -h, --help                        output usage information
 ```
 
-While GoFSH is running, it will print status messages as it processes your project files.
+While GoFSH is running, it will print status messages as it processes your project files. The following sections give further detail on using certain options.
+
+### `style`
+The `style` option has four values:
+* `group-by-fsh-type`: Definitions are written to files based on what type of FSH definition they are (Alias, Profile, Extension, etc.). This is the default choice.
+* `group-by-profile`:  Profiles are each written to an individual file. Instances and Invariants that pertain only to a certain Profile are then included in the same file as that Profile. The remaining definitions are grouped as in the `group-by-fsh-type` option.
+* `single-file`: All definitions are written to one file.
+* `file-per-definition`: Each standalone FSH definition is written to an individual file. Only Aliases are combined into one `aliases.fsh` file.
+
+### `fshing-trip`
+If this flag is added, after GoFSH runs, SUSHI will run on the output of GoFSH. The output of SUSHI will then be compared to the original input to GoFSH (FHIR is compared to FHIR), and a visualization of differences between the original input and the SUSHI output will be created in `<output-folder>/fshing-trip-comparison.html`. If the `--installed-sushi` flag is set, then this process will use whichever version of SUSHI you have globally installed. Otherwise GoFSH will use SUSHI version 1.1.0.
 
 ## GoFSH Inputs
 
 GoFSH takes FHIR StructureDefinitions and other FHIR conformance definitions (e.g., ValueSets, CodeSystems) as input. GoFSH requires that these files be JSON. Every JSON file contained in the input directory, or its subdirectories, will be processed by GoFSH into FSH.
 
-{{% alert title="Warning" color="warning" %}}
-GoFSH is still under development, and can not generate FSH for all FHIR artifacts. Please see the section below on [limitations](#limitations-on-inputs) for more details.
-{{% /alert %}}
 
 GoFSH does not require any configuration, but if the input FHIR artifacts depend on FHIR artifacts not contained in FHIR R4, these dependencies should be specified with the `-d` flag. For example, the [mcode-cancer-patient](http://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-patient.html) profile in the [mCODE Implementation Guide](http://hl7.org/fhir/us/mcode/) is derived from the [us-core-patient](http://hl7.org/fhir/us/core/STU3.1/StructureDefinition-us-core-patient.html) profile in the [US Core Implementation Guide](http://hl7.org/fhir/us/core/). If you wanted to use GoFSH to convert the mcode-cancer-patient profile to FSH, you should specify US Core as a dependency:
 ```shell
@@ -40,16 +50,10 @@ GoFSH does not require any configuration, but if the input FHIR artifacts depend
 GoFSH can still generate FSH when dependencies are omitted, but the resulting FSH will be incomplete.
 {{% /alert %}}
 
-### Limitations on Inputs
+{{% alert title="Warning" color="warning" %}}
+GoFSH cannot generate FSH from XML inputs, only JSON is allowed.
+{{% /alert %}}
 
-Note that GoFSH is not complete, and cannot be applied to all FHIR artifacts. The capabilities and limitations of GoFSH are given below.
-
-* GoFSH outputs valid FSH for most profiles and extensions.
-  * Generated profile and extension definitions should be technically correct, but may not use the most efficient FSH representation or follow FSH authoring best practices.
-* GoFSH does not output the content of Code System definitions; it declares them using keywords, but does not generate any of their rules.
-* GoFSH does not output ValueSet definitions.
-* GoFSH does not output Instance definitions (this includes examples, as well as any definitions that must be created in FSH using the Instance keyword).
-* GoFSH does not support generating FSH from FHIR XML definitions.
 
 ## GoFSH Outputs
 


### PR DESCRIPTION
This updates the documentation for the release of GoFSH 1.0. The following changes were added:
* Add API documentation of `fshToFhir` function in SUSHI.
* Add API documentation of `fhirToFsh` function in GoFSH.
* Document `style` option for GoFSH.
* Document `fshing-trip` option for GoFSH.
* Clean up old references in the GoFSH documentation to being a pre-release.