### PR TITLE
Update path information for IG Publisher 

### DIFF
--- a/content/docs/SUSHI/project/_index.md
+++ b/content/docs/SUSHI/project/_index.md
@@ -23,7 +23,7 @@ Each FSH file can contain multiple FSH definitions of varying types. FSH file na
 
 ### Using the HL7 IG Publisher and Auto-Builder
 
-This project structure integrates with the HL7 IG Publisher [Auto-Builder](https://github.com/FHIR/auto-ig-builder/blob/master/README.md). When the IG Publisher detects an **input/fsh** subdirectory, it will automatically run SUSHI on that directory and output the SUSHI results to a **fsh-generated** directory (e.g., **simple-project/fsh-generated** in the example above). It will then continue with the normal IG Publisher process.
+This project structure integrates with the HL7 IG Publisher [Auto-Builder](https://github.com/FHIR/auto-ig-builder/blob/master/README.md). When the IG Publisher detects an **input/fsh** subdirectory, it will automatically run SUSHI on the project directory and output the SUSHI results to a **fsh-generated** directory (e.g., **simple-project/fsh-generated** in the example above). It will then continue with the normal IG Publisher process.
 
 This approach allows a GitHub repository to be configured such that whenever changes to FSH files are pushed to GitHub, the [Auto-Builder](https://github.com/FHIR/auto-ig-builder/blob/master/README.md) will pick them up, run the SUSHI/IG Publisher process, and publish the resulting IG to [http://build.fhir.org](http://build.fhir.org).
 


### PR DESCRIPTION
The IG Publisher now uses the root FSH project directory as the input directory, so this PR updates the documentation to reflect that.