### PR TITLE
Document new SUSHI --init fields 

### DIFF
--- a/content/docs/SUSHI/project/_index.md
+++ b/content/docs/SUSHI/project/_index.md
@@ -95,6 +95,8 @@ Id (Default: fhir.example): my.id
 Canonical (Default: http://example.org): http://myid.org
 Status (Default: draft): active
 Version (Default: 0.1.0): 2.0.0
+Publisher Name (Default: Example Publisher): MyPublisher
+Publisher Url (Default: http://example.org/example-publisher): http://my-publisher.org
 Initialize SUSHI project in C:\Users\shorty\dev\NewIG? [y/n]: y
 ```
 These values are used to generate a simple **sushi-config.yaml** file and a corresponding IG-Publisher-compatible project structure:


### PR DESCRIPTION
This documents the new publisher fields that can be entered in `sushi --init` that are added in this PR: https://github.com/FHIR/sushi/pull/899.