### PR TITLE
I Promise the API Documentation Is Better

### DIFF
--- a/content/docs/SUSHI/API/_index.md
+++ b/content/docs/SUSHI/API/_index.md
@@ -24,7 +24,7 @@ fshToFhir(fshString[, options])
 See the [configuration](/docs/sushi/configuration/#full-configuration) documentation for more information on `canonical`, `version`, `fhirVersion`, and `dependencies`. These properties correspond to the properties of the same name that are used in `sushi-config.yaml`.
 
 ## Return Value
-An object with the following attributes:
+A `Promise` that resolves to an object with the following attributes:
 * `fhir` - An array of FHIR definitions generated from the input FSH.
 * `errors` - An array of strings containing any errors detected during processing.
 * `warnings` - An array of strings containing any warnings detected during processing.
@@ -40,17 +40,29 @@ Once `fsh-sushi` is installed as a dependency of your project, you can `import` 
 import { sushiClient } from 'fsh-sushi';
 
 // Example basic usage
-sushiClient.fshToFhir('Your FSH here');
+sushiClient
+  .fshToFhir('Your FSH here')
+  .then((results) => {
+    // handle results
+  })
+  .catch((err) => {
+    // handle thrown errors
+  });
 
 // Example usage with options
-sushiClient.fshToFhir(
-  'Your FSH here',
-  {
-    canonical: 'http://example.com',
-    version: '1.2.3',
-    fhirVersion: '4.0.1',
-    dependencies: [{ packageId: 'hl7.fhir.us.core', version: '3.1.0' }],
-    logLevel: 'error'
+sushiClient
+  .fshToFhir('Your FSH here', {
+    canonical: "http://example.com",
+    version: "1.2.3",
+    fhirVersion: "4.0.1",
+    dependencies: [{ packageId: "hl7.fhir.us.core", version: "3.1.0" }],
+    logLevel: "error",
+  })
+  .then((results) => {
+    // handle results
+  })
+  .catch((err) => {
+    // handle thrown errors
   });
 ```
 

--- a/content/docs/goFSH/API/_index.md
+++ b/content/docs/goFSH/API/_index.md
@@ -27,7 +27,7 @@ fhirToFsh(fhir[, options])
     * `instances` - A `Map` containing all `Instance` definitions as values.
     * `invariants` - A `Map` containing all `Invariant` definitions as values.
     * `mappings` - A `Map` containing all `Mapping` definitions as values.
-    
+
     For each `Map`, the keys are the name of the FSH definition. For example, if the definition was:
     ```
     Profile: MyPatient
@@ -36,7 +36,7 @@ fhirToFsh(fhir[, options])
     The key would be `MyPatient`.
 
 ## Return Value
-An object with the following attributes:
+A `Promise` that resolves to an object with the following attributes:
 * `fsh` - The generated FSH, styled according to the `style` parameter.
 * `configuration` - An object representing the `sushi-config.yaml` file that would be generated if GoFSH was running in a command line interface.
 * `errors` - An array of strings containing any errors detected during processing.
@@ -53,15 +53,27 @@ Once `gofsh` is installed as a dependency of your project, you can `import` and 
 import { gofshClient } from 'gofsh';
 
 // Example basic usage
-gofshClient.fhirToFsh(['Your FHIR here']);
+gofshClient
+  .fhirToFsh(['{ Your FHIR here }'])
+  .then((results) => {
+    // handle results
+  })
+  .catch((err) => {
+    // handle thrown errors
+  });
 
 // Example usage with options
-gofshClient.fhirToFsh(
-  ['Your FHIR here'], 
-  {
+gofshClient
+  .fhirToFsh(['{ Your FHIR here }'], {
     dependencies: ["hl7.fhir.us.mcode@1.0.0"],
     style: "map",
-    logLevel: "silent"
+    logLevel: "silent",
+  })
+  .then((results) => {
+    // handle results
+  })
+  .catch((err) => {
+    // handle thrown errors
   });
 ```
 


### PR DESCRIPTION
I was investigating a report that our GoFSH API was not working correctly and noticed that the API doc does not indicate that the function returns a `Promise`.  This is pretty important, so I thought we should call it out in the doc and in the example usage.