### PR TITLE
Minor documentation improvements

### DIFF
--- a/content/docs/SUSHI/API/_index.md
+++ b/content/docs/SUSHI/API/_index.md
@@ -25,9 +25,10 @@ See the [configuration](/docs/sushi/configuration/#full-configuration) documenta
 
 ## Return Value
 A `Promise` that resolves to an object with the following attributes:
+
 * `fhir` - An array of FHIR definitions generated from the input FSH.
-* `errors` - An array of strings containing any errors detected during processing.
-* `warnings` - An array of strings containing any warnings detected during processing.
+* `errors` - An array of objects containing any errors detected during processing. Each object has a `message` with the error message and optionally has `input` and `location` properties with additional information.
+* `warnings` - An array of objects containing any warnings detected during processing. Each object has a `message` with the warning message and optionally has `input` and `location` properties with additional information.
 
 ## Usage
 To use `fshToFhir`, you must first install `fsh-sushi` as a dependency of your project:

--- a/content/docs/SUSHI/configuration/exhaustive-config.yaml
+++ b/content/docs/SUSHI/configuration/exhaustive-config.yaml
@@ -173,6 +173,7 @@ menu:
 parameters:
   excludettl: true
   validation: [allow-any-extensions, no-broken-links]
+  show-inherited-invariants: false
 
 # The FSHOnly flag indicates if only FSH resources should be exported.
 # If set to true, no IG related content will be generated.

--- a/content/docs/Tutorials/basic/_index.md
+++ b/content/docs/Tutorials/basic/_index.md
@@ -208,9 +208,9 @@ Run SUSHI again, and re-generate the IG.
 
 Now, add constraints and/or extensions to the Veterinarian profile:
 
-* Add qualifications consistent with a Veterinary practice. Qualifications are taken from code system http://nucc.org/provider-taxonomy, and the code is 174M00000X, for "Veterinarian".
+* Add qualifications consistent with a Veterinary practice. Qualifications are taken from code system `http://nucc.org/provider-taxonomy`, and the code is `174M00000X`, for "Veterinarian".
 
-* In addition, slice the `identifier` array, making a license number required. The code system is http://terminology.hl7.org/CodeSystem/v2-0203 and the code is LN, for "License number".
+* In addition, slice the `identifier` array, making a license number required. The code system is `http://terminology.hl7.org/CodeSystem/v2-0203` and the code is `LN`, for "License number".
 
 If you need help with this, you can refer to the [assignment rules](https://build.fhir.org/ig/HL7/fhir-shorthand/reference.html#assignment-rules) and [slicing rules](https://build.fhir.org/ig/HL7/fhir-shorthand/reference.html#contains-rules-for-slicing) sections of the specification. If you still need help, you can peek at the FSH files in the **FishExampleComplete** directory.
 

--- a/content/docs/docs-legacy/SUSHI/configuration/exhaustive-config.yaml
+++ b/content/docs/docs-legacy/SUSHI/configuration/exhaustive-config.yaml
@@ -176,6 +176,7 @@ menu:
 parameters:
   excludettl: true
   validation: [allow-any-extensions, no-broken-links]
+  show-inherited-invariants: false
 
 # The history property corresponds to package-list.json. SUSHI will
 # use the existing top-level properties in its config to populate the

--- a/content/docs/docs-legacy/Tutorials/basic/_index.md
+++ b/content/docs/docs-legacy/Tutorials/basic/_index.md
@@ -215,9 +215,9 @@ Run SUSHI again, and re-generate the IG.
 
 Now, add constraints and/or extensions to the Veterinarian profile:
 
-* Add qualifications consistent with a Veterinary practice. Qualifications are taken from code system http://nucc.org/provider-taxonomy, and the code is 174M00000X, for "Veterinarian".
+* Add qualifications consistent with a Veterinary practice. Qualifications are taken from code system `http://nucc.org/provider-taxonomy`, and the code is `174M00000X`, for "Veterinarian".
 
-* In addition, slice the `identifier` array, making a license number required. The code system is http://terminology.hl7.org/CodeSystem/v2-0203 and the code is LN, for "License number".
+* In addition, slice the `identifier` array, making a license number required. The code system is `http://terminology.hl7.org/CodeSystem/v2-0203` and the code is `LN`, for "License number".
 
 If you need help with this, you can refer to the [assignment rules](https://build.fhir.org/ig/HL7/fhir-shorthand/reference.html#assignment-rules) and [slicing rules](https://build.fhir.org/ig/HL7/fhir-shorthand/reference.html#contains-rules-for-slicing) sections of the specification. If you still need help, you can peek at the FSH files in the **FishExampleComplete** directory.
 


### PR DESCRIPTION
This PR fixes #50 and #58 and makes one additional clarification:

- To fix #58, this PR puts the codes and code systems into code styled markdown to prevent code systems from rendering as real URLs.
- To fix #50, this PR adds the additional parameter `show-inherited-invariants` to the `exhaustive-config.yaml`.
- While working on FPL, I noticed that the return type described in the SUSHI API was incorrect. I added a bit more information to make sure it reflected what actually is returned, but any feedback on clarity is helpful!