### PR TITLE
Add missing closing tag for alert

### DIFF
--- a/content/docs/SUSHI/running/_index.md
+++ b/content/docs/SUSHI/running/_index.md
@@ -120,6 +120,7 @@ While SUSHI is running, it will print status messages as it processes your proje
 ```
 
 {{% alert title="Note" color="primary" %}} The following message is expected, and should be ignored:(node:46420) Warning: Accessing non-existent property 'INVALID_ALT_NUMBER' of module exports inside circular dependency (Use `node --trace-warnings ...` to show where the warning was created)
+{{% /alert %}}
 
 ## Error Messages
 


### PR DESCRIPTION
Super small PR to add in a missing closing alert tag. This fixes an issue I ran into where one of the `Note` sections didn't get properly closed.

You can see on the [Running SUSHI page](https://fshschool.org/docs/sushi/running/#status-messages) that the Note about the "Error Messages" section extends beyond where it should and ends up containing the remainder of the page. It also actually takes over some nicer styling as well, which came back as soon as I added in the closing tag.