### PR TITLE
Update to a nested list

### DIFF
--- a/content/docs/SUSHI/tips/_index.md
+++ b/content/docs/SUSHI/tips/_index.md
@@ -103,11 +103,11 @@ See the following documentation for additional details:
 The IG Publisher supports including instances of logical models as binary resources. This feature was announced and discussed in a [Logical Model Examples](https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/Logical.20Model.20Examples/near/251192344) thread on chat.fhir.org.  The basic steps an author needs to take in order to include logical model examples in a SUSHI project are:
 
 1. Add the example to the `input/resources` or `input/examples` folder
-    a. The file name of the example should be `Binary-{id}.json` or `Binary-{id}.xml` (substituting `{id}` for the real id)
+    - The file name of the example should be `Binary-{id}.json` or `Binary-{id}.xml` (substituting `{id}` for the real id)
 2. Add an entry for the example in the `sushi-config.yaml` `resources` property
-    a. Specify a `name`
-    b. Specify `exampleCanonical` pointing to the canonical of your logical model
-    c. Add an extension w/ the proper resource format (`application/fhir+json` or `application/xml`)
+    - Specify a `name`
+    - Specify `exampleCanonical` pointing to the canonical of your logical model
+    - Add an extension w/ the proper resource format (`application/fhir+json` or `application/xml`)
 
 For example, given the following simple logical model definition in an IG w/ IG canonical root `http://example.org`:
 


### PR DESCRIPTION
This updates how a nested list is used in the documentation to fix an issue where it wasn't properly rendering the nested list.

On the documentation site here https://fshschool.org/docs/sushi/tips/#instances-of-logical-models you can see that the list of steps to add a Logical Model example has a `1.` and `2.`, but the `a.`, `b.`, and `c.` in that list were likely intended to be list items under the `1.` and `2.`, but are just rendered as if they are part of that item and just part of a larger paragraph.

This PR makes it so they are bullet points underneath the `1.` and `2.

Photos of the difference:

![image](https://user-images.githubusercontent.com/30803904/208492243-01bf6b9e-c7fe-446b-b89d-930f311c76ba.png)
 is updated to
![image](https://user-images.githubusercontent.com/30803904/208492489-286b28cd-830a-43b8-8325-ebc5e2137918.png)

