### PR TITLE
Add config to support asdf version manager

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -92,11 +92,15 @@ navbar_logo = true
 footer_about_disable = false
 
 # Adds a reading time to the top of each doc.
-# If you want this feature, but occasionally need to remove the Reading time from a single page, 
+# If you want this feature, but occasionally need to remove the Reading time from a single page,
 # add "hide_readingtime: true" to the page's front matter
 [params.ui.readingtime]
 enable = false
 
+# Modify the allowed environment variables to support use with asdf
+# See: https://github.com/gohugoio/hugo/issues/9811
+[security.exec]
+  osEnv = ['(?i)^(PATH|PATHEXT|APPDATA|TMP|TEMP|TERM)$','^ASDF_DIR$','^HOME$']
 
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.


### PR DESCRIPTION
This update allows for node versions that are managed by asdf. The solution was found here: https://github.com/gohugoio/hugo/issues/9811.

If you don't use asdf, that's fine; please just ensure you can correctly build the site.