### PR TITLE
Update links to parameters documentation

### DIFF
--- a/content/docs/SUSHI/configuration/exhaustive-config.yaml
+++ b/content/docs/SUSHI/configuration/exhaustive-config.yaml
@@ -190,9 +190,10 @@ menu:
 # The parameters property represents IG.definition.parameter. Rather
 # than a list of code/value pairs (as in the ImplementationGuide
 # resource), the code is the YAML key. If a parameter allows repeating
-# values, the value in the YAML should be a sequence/array. For a
-# partial list of allowed parameters see:
-# https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
+# values, the value in the YAML should be a sequence/array. For parameters
+# defined by core FHIR see: http://build.fhir.org/codesystem-guide-parameter-code.html.
+# For parameters defined by the FHIR Tools IG  see:
+# http://build.fhir.org/ig/FHIR/fhir-tools-ig/branches/master/CodeSystem-ig-parameters.html
 parameters:
   excludettl: true
   validation: [allow-any-extensions, no-broken-links]

--- a/content/docs/SUSHI/tips/_index.md
+++ b/content/docs/SUSHI/tips/_index.md
@@ -7,7 +7,7 @@ description: >
 
 ## Specifying Additional Resource Paths
 
-Sometimes authors may wish to put predefined resources in folders other than the normally supported `input` sub-folders. To support this, SUSHI now recognizes the [ImplementationGuide parameter](https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters) `path-resource`. Authors can include this parameter in `sushi-config.yaml` to specify relative paths to additional folders that contain predefined resources. For example, the following can now be used in `sushi-config.yaml` to include resources from the sub-folder `predefined-resources`:
+Sometimes authors may wish to put predefined resources in folders other than the normally supported `input` sub-folders. To support this, SUSHI now recognizes the [ImplementationGuide parameter](http://build.fhir.org/codesystem-guide-parameter-code.html) `path-resource`. Authors can include this parameter in `sushi-config.yaml` to specify relative paths to additional folders that contain predefined resources. For example, the following can now be used in `sushi-config.yaml` to include resources from the sub-folder `predefined-resources`:
 
   ```yaml
   parameters:


### PR DESCRIPTION
I just realized this change was in #72, which has been waiting on SUSHI 3.0 documentation changes, but these changes should be merged now since they are in the current release of SUSHI.

Summary from the previous PR:

I updated the `exhaustive-config.yaml` file and one link in the Tips and Tricks section to reflect the new links for parameters, which were updated in [SUSHI #1164](https://github.com/FHIR/sushi/pull/1164).

