### PR TITLE
Documentation for Configurable Log Level

### DIFF
--- a/content/docs/SUSHI/running/_index.md
+++ b/content/docs/SUSHI/running/_index.md
@@ -35,7 +35,7 @@ The `build` command is used to build a SUSHI project. It can be used as follows:
 where options include the following (in any order):
 
 ```text
--l, --log-level <level>  specify the level of log messages: error, warn, info (default), debug
+-l, --log-level <level>  specify the level of log messages (default: "info") (choices: "error", "warn", "info", "debug")
 -o, --out <out>          the path to the output folder
 -p, --preprocessed       output FSH produced by preprocessing steps
 -r, --require-latest     exit with error if this is not the latest version of SUSHI (default: false)

--- a/content/docs/SUSHI/running/_index.md
+++ b/content/docs/SUSHI/running/_index.md
@@ -35,12 +35,12 @@ The `build` command is used to build a SUSHI project. It can be used as follows:
 where options include the following (in any order):
 
 ```text
--d, --debug           output extra debugging information
--o, --out <out>       the path to the output folder
--p, --preprocessed    output FSH produced by preprocessing steps
--r, --require-latest  exit with error if this is not the latest version of SUSHI (default: false)
--s, --snapshot        generate snapshot in Structure Definition output (default: false)
--h, --help            display help for command
+-l, --log-level <level>  specify the level of log messages: error, warn, info (default), debug
+-o, --out <out>          the path to the output folder
+-p, --preprocessed       output FSH produced by preprocessing steps
+-r, --require-latest     exit with error if this is not the latest version of SUSHI (default: false)
+-s, --snapshot           generate snapshot in Structure Definition output (default: false)
+-h, --help               display help for command
 ```
 
 Further information about each option can be found in [Build Command Option Details](#build-command-option-details).


### PR DESCRIPTION
This updates our documentation referencing the `--debug` CLI option to the new `--log-level` option.

This branch targets `cli-command-documentation` because it fits in with the latest changes for CLI commands.