### PR TITLE
Update GH Action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,9 +6,9 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           fetch-depth: 0
@@ -20,12 +20,12 @@ jobs:
           extended: true
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: '18.x'
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
Our last deploy job has been stuck for 14 hours. I restarted it, but it seems stuck again.

I think the issue is that [Ubuntu 18 has been deprecated for GitHub Actions](https://github.com/actions/runner-images/issues/6002). This PR updates Ubuntu to 22 and updates a few of the other actions as well.

Unfortunately, I think the only way to test this is to merge it and let it run.