### PR TITLE
Logical model examples without resourceType or id

### DIFF
--- a/content/docs/SUSHI/tips/_index.md
+++ b/content/docs/SUSHI/tips/_index.md
@@ -147,6 +147,11 @@ resources:
 
 Both approaches will result in your logical model example being listed and displayed as a proper example of the logical model.
 
+If the logical model does not have `resourceType` or `id`, the same steps as above can be used with a few small adjustments:
+
+- In step 1, the file name of the example can be any valid file name (e.g. `hook-example.json`)
+- In step 2, the key in the resources list should be `Binary/{filename}`, where `{filename}` matches the the file name of the example without the file extension (e.g. `Binary/hook-example`)
+
 ## Manual Slice Ordering
 
 {{% small-pageinfo color="primary" %}}

--- a/content/docs/SUSHI/tips/_index.md
+++ b/content/docs/SUSHI/tips/_index.md
@@ -120,14 +120,15 @@ Logical: MyLM
 Id: MyLM
 Title: "My LM"
 Description: "This is mine"
-* important 1..1 SU boolean "Is this resource important"
+* id 1..1 SU string "Identifier for the logical model"
+* important 1..1 SU boolean "Is this logical model important"
 ```
 
 Create the file `input/examples/Binary-my-logical-example.json`:
 
 ```json
 {
-  "resourceType": "MyLM",
+  "resourceType": "http://example.org/StructureDefinition/MyLM",
   "id": "my-logical-example",
   "important": true
 }

--- a/content/docs/SUSHI/tips/_index.md
+++ b/content/docs/SUSHI/tips/_index.md
@@ -120,7 +120,7 @@ Logical: MyLM
 Id: MyLM
 Title: "My LM"
 Description: "This is mine"
-* id 1..1 SU string "Identifier for the logical model"
+* id 1..1 SU id "Identifier for the logical model"
 * important 1..1 SU boolean "Is this logical model important"
 ```
 

--- a/content/docs/SUSHI/tips/_index.md
+++ b/content/docs/SUSHI/tips/_index.md
@@ -139,7 +139,7 @@ And add the following in your `sushi-config.yaml`:
 resources:
   Binary/my-logical-example:
     extension:
-      - url: http://hl7.org/fhir/StructureDefinition/implementationguide-resource-format
+      - url: http://hl7.org/fhir/tools/StructureDefinition/implementationguide-resource-format
         valueCode: application/fhir+json
     name: Example of LM
     exampleCanonical: http://example.org/StructureDefinition/MyLM


### PR DESCRIPTION
This PR adds a note to the Tips and Tricks section about logical model examples without resource type and id. I wasn't exactly sure where this should fit because it is really similar to the existing documentation. Let me know what you think.

Note: this approach is based on discussion on Zulip [here](https://chat.fhir.org/#narrow/stream/215610-shorthand/topic/How.20do.20I.20get.20SUSHI.20to.20ignore.20a.20binary.20JSON.20logical.20instance.3F/near/407798801).

**Do not merge this PR until there is a SUSHI release that includes support for this.**