### PR TITLE
Documentation for extensions on IG.definition

### DIFF
--- a/content/docs/SUSHI/configuration/_index.md
+++ b/content/docs/SUSHI/configuration/_index.md
@@ -142,6 +142,7 @@ The table below lists all configuration properties that can be used in SUSHI's *
 | copyrightLabel| copyrightLabel | As specified in the IG resource - **Note:** this is an R5 IG element |
 | copyrightYear or copyrightyear | N/A | Used to add a `copyrightyear` parameter to `IG.definition.parameter` |
 | date | date | As specified in the IG resource |
+| definition <br> └ extension | definition.extension | <span class="tag">SUSHI 3.0</span>A list of extensions that apply to `IG.definition`. **Note:** the only property supported on the `definition` property is `extension`. |
 | description | description | As specified in the IG resource |
 | dependencies | dependsOn | A `key: value` pair, where key is the package id and value is the version (or `dev`/`current`). For advanced use cases, the value can be an object with keys for `id`, `uri` and `version`. For R5 IG resources, the key `reason` can also be provided. |
 | experimental | experimental | As specified in the IG resource |

--- a/content/docs/SUSHI/configuration/exhaustive-config.yaml
+++ b/content/docs/SUSHI/configuration/exhaustive-config.yaml
@@ -73,6 +73,15 @@ global:
   Patient: http://example.org/fhir/StructureDefinition/my-patient-profile
   Encounter: http://example.org/fhir/StructureDefinition/my-encounter-profile
 
+# NOTE: All of the properties of IG.definition are abstracted to
+# individual top-level configuration properties (below). This
+# definition property should only be used to provide extensions
+# that have a context of IG.definition.
+definition:
+  extension:
+    - url: http://example.org/example/ig-definition-ext
+      valueBoolean: true
+
 # The resources property corresponds to IG.definition.resource.
 # SUSHI can auto-generate all of the resource entries based on
 # the FSH definitions and/or information in any user-provided


### PR DESCRIPTION
Add a row in the Configuration list to document SUSHI's new support for IG.definition extensions. This is the first property that we want to list out that isn't just a top-level property, and I tried to indicate it as clearly as possible, but I'm open to feedback on how it is listed. I also included the property in the `exhaustive-config.yaml` file.

**Note**: Do not merge this until SUSHI 3.9.0 is released.