### PR TITLE
Remove specific tags for SUSHI 3.0.0 + Document new CLI command options

### DIFF
--- a/content/docs/SUSHI/configuration/_index.md
+++ b/content/docs/SUSHI/configuration/_index.md
@@ -81,7 +81,7 @@ If the author wants SUSHI to do additional Implementation Guide (IG) processing,
   * `normative+trial-use`: official release with mixture of trial use and normative content
 
 {{% alert title="Tip" color="success" %}}
-SUSHI can generate a simple configuration file for you with the `--init` [option](/docs/sushi/project/#initializing-a-sushi-project)
+SUSHI can generate a simple configuration file for you with the `init` [command](/docs/sushi/project/#initializing-a-sushi-project)
 {{% /alert %}}
 
 ## FSH and IG Processing: Recommended Configuration
@@ -142,7 +142,7 @@ The table below lists all configuration properties that can be used in SUSHI's *
 | copyrightLabel| copyrightLabel | As specified in the IG resource - **Note:** this is an R5 IG element |
 | copyrightYear or copyrightyear | N/A | Used to add a `copyrightyear` parameter to `IG.definition.parameter` |
 | date | date | As specified in the IG resource |
-| definition <br> └ extension | definition.extension | <span class="tag">SUSHI 3.0</span>A list of extensions that apply to `IG.definition`. **Note:** the only property supported on the `definition` property is `extension`. |
+| definition <br> └ extension | definition.extension | A list of extensions that apply to `IG.definition`. **Note:** the only property supported on the `definition` property is `extension`. |
 | description | description | As specified in the IG resource |
 | dependencies | dependsOn | A `key: value` pair, where key is the package id and value is the version (or `dev`/`current`). For advanced use cases, the value can be an object with keys for `id`, `uri` and `version`. For R5 IG resources, the key `reason` can also be provided. |
 | experimental | experimental | As specified in the IG resource |
@@ -153,7 +153,7 @@ The table below lists all configuration properties that can be used in SUSHI's *
 | groups | definition.grouping | A `key: value` pair, where key is the group id and value is the description of the group. For advanced use cases, the value can be an object with keys for `name`, `description`, and `resources`. See the [Exhaustive Example](#exhaustive-example) for details. |
 | id | id | As specified in the IG resource |
 | implicitRules | implicitRules | As specified in the IG resource |
-| instanceOptions | N/A | `key: value` pairs, where keys are `setId`, `setMetaProfile`, and `manualSliceOrdering`. <ul><li>The `setId` value controls whether `id` is set on generated instances. Options are `always` (set `id` on all instances [the default]) or `standalone-only` (set `id` for instances where the `Usage` keyword is NOT `#inline`).</li><li>The `setMetaProfile` value controls whether `meta.profile` is set on generated instances. It can have the following values: `always` (set meta.profile for all instances [the default]), `never` (do not set meta.profile on any instances), `inline-only` (set `meta.profile` only for instances of profiles with `Usage` keyword set to `#inline`), or `standalone-only` (set `meta.profile` for instances where the `Usage` keyword is NOT `#inline`).</li><li><span class="tag">SUSHI 3.0</span>The `manualSliceOrdering` value controls whether slice ordering is determined exclusively by the order in which slices are referenced in an instance's FSH rules. When this flag is set to `true`, manual ordering is enabled (see [Manual Slice Ordering](/docs/sushi/tips/#manual-slice-ordering)).</li></ul> |
+| instanceOptions | N/A | `key: value` pairs, where keys are `setId`, `setMetaProfile`, and `manualSliceOrdering`. <ul><li>The `setId` value controls whether `id` is set on generated instances. Options are `always` (set `id` on all instances [the default]) or `standalone-only` (set `id` for instances where the `Usage` keyword is NOT `#inline`).</li><li>The `setMetaProfile` value controls whether `meta.profile` is set on generated instances. It can have the following values: `always` (set meta.profile for all instances [the default]), `never` (do not set meta.profile on any instances), `inline-only` (set `meta.profile` only for instances of profiles with `Usage` keyword set to `#inline`), or `standalone-only` (set `meta.profile` for instances where the `Usage` keyword is NOT `#inline`).</li><li>The `manualSliceOrdering` value controls whether slice ordering is determined exclusively by the order in which slices are referenced in an instance's FSH rules. When this flag is set to `true`, manual ordering is enabled (see [Manual Slice Ordering](/docs/sushi/tips/#manual-slice-ordering)).</li></ul> |
 | jurisdiction | jurisdiction | As specified in the IG resource |
 | language | language | As specified in the IG resource |
 | license | license | As specified in the IG resource |

--- a/content/docs/SUSHI/installation/_index.md
+++ b/content/docs/SUSHI/installation/_index.md
@@ -27,12 +27,8 @@ To install SUSHI, open up a command prompt and type the following command:
 Check the installation via the command below:
 
 ```shell
-{{< terminal >}} sushi --help
+{{< terminal >}} sushi help
 ```
-
-{{% small-pageinfo color="primary" %}}
-<span class="tag">SUSHI 3.0</span>For SUSHI 3.0.0 and later, use `sushi help`.
-{{% /small-pageinfo %}}
 
 If the command outputs instructions on using the SUSHI command line interface (CLI), you're ready to run SUSHI.
 

--- a/content/docs/SUSHI/project/_index.md
+++ b/content/docs/SUSHI/project/_index.md
@@ -33,6 +33,7 @@ Id (Default: fhir.example): my.id
 Canonical (Default: http://example.org): http://myid.org
 Status (Default: draft): active
 Version (Default: 0.1.0): 2.0.0
+Release Label (Default: ci-build): trial-use
 Publisher Name (Default: Example Publisher): MyPublisher
 Publisher Url (Default: http://example.org/example-publisher): http://my-publisher.org
 Initialize SUSHI project in C:\Users\shorty\dev\my-project? [y/n]: y

--- a/content/docs/SUSHI/project/_index.md
+++ b/content/docs/SUSHI/project/_index.md
@@ -25,11 +25,7 @@ The **sushi-config.yaml** file provides project configuration data to SUSHI. It 
 
 ## Initializing a SUSHI Project
 
-Setting up a fully-featured FSH project can be complex, so SUSHI provides an `--init` argument to do it automatically. When `sushi --init` is run, SUSHI will request project information from the user:
-
-{{% small-pageinfo color="primary" %}}
-<span class="tag">SUSHI 3.0</span>For SUSHI 3.0.0 and later, use `sushi init`.
-{{% /small-pageinfo %}}
+Setting up a fully-featured FSH project can be complex, so SUSHI provides an `init` command to do it automatically. When `sushi init` is run, SUSHI will request project information from the user:
 
 ```text
 Name (Default: ExampleIG): my-project

--- a/content/docs/SUSHI/running/_index.md
+++ b/content/docs/SUSHI/running/_index.md
@@ -20,7 +20,7 @@ SUSHI is executed from the command line. The general form of the SUSHI execution
 
 Supported commands are `build`, `init`, `update-dependencies`, and `help`.
 
-Use `sushi --version` and `sushi help` to get basic information about the current SUSHI version.
+Use `sushi --version` to get basic information about the current SUSHI version. Use `sushi help` to get basic information about SUSHI, and use `sushi help {command}` to get information about a specific command and its options (e.g., `sushi help build`).
 
 ### SUSHI Commands
 

--- a/content/docs/SUSHI/running/_index.md
+++ b/content/docs/SUSHI/running/_index.md
@@ -38,10 +38,11 @@ where options include the following (in any order):
 
 ```text
 -l, --log-level <level>  specify the level of log messages (default: "info") (choices: "error", "warn", "info", "debug")
--o, --out <out>          the path to the output folder
+-o, --out <out>          the path to the output folder (default: "fsh-generated")
 -p, --preprocessed       output FSH produced by preprocessing steps
 -r, --require-latest     exit with error if this is not the latest version of SUSHI (default: false)
 -s, --snapshot           generate snapshot in Structure Definition output (default: false)
+-c, --config <config>    override elements in sushi-config.yaml (supported: 'version', 'status', 'releaselabel') (eg: --config status:draft)
 -h, --help               display help for command
 ```
 
@@ -130,6 +131,11 @@ Once you have finished reviewing your preprocessed FSH, we recommend deleting th
 
 By default, SUSHI only generates the [profile differential](https://www.hl7.org/fhir/R4/profiling.html#snapshot), allowing the IG Publisher to create the [profile snapshot](https://www.hl7.org/fhir/R4/profiling.html#snapshot). This is the approach recommended by HL7 FHIR leadership. If authors prefer, the `--snapshot` (or `-s`) option can be used to cause SUSHI to generate the snapshot without having to run the IG Publisher.
 
+### `--config`
+
+Typically, SUSHI uses the `sushi-config.yaml` file to define the configuration options it uses when processing FSH. However, in rare cases, it may be useful to override the values provided in `sushi-config.yaml` without changing the file itself. For these cases, the `--config` (or `-c`) option can be used to specify a configuration property and the override value for it. Currently, this option only allows `version`, `status`, and `releaselabel` to be overridden.
+
+For example, specifying `sushi build . --config status:active` can be used to specify that the status should be "active" for that particular build of SUSHI.
 
 ## Status Messages
 

--- a/content/docs/SUSHI/running/_index.md
+++ b/content/docs/SUSHI/running/_index.md
@@ -15,20 +15,12 @@ This documentation assumes you have a SUSHI-compliant project structure and conf
 SUSHI is executed from the command line. The general form of the SUSHI execution command is as follows:
 
 ```shell
-{{< terminal >}} sushi {options}
+{{< terminal >}} sushi {command} {options}
 ```
 
-Use `sushi --version` and `sushi --help` to get basic information about the current SUSHI version.
+Supported commands are `build`, `init`, `update-dependencies`, and `help`.
 
-{{% small-pageinfo color="primary" %}}
-<span class="tag">SUSHI 3.0</span>For SUSHI 3.0.0 and later, the general form of the SUSHI execution command is:
-
-```shell
-$ sushi {command} {options}
-```
-
-Supported commands are `build`, `init`, `update-dependencies`, and `help` (which replaces `sushi --help`).
-{{% /small-pageinfo %}}
+Use `sushi --version` and `sushi help` to get basic information about the current SUSHI version.
 
 ### SUSHI Commands
 
@@ -39,23 +31,14 @@ SUSHI provides various commands to use with FSH projects. The following sections
 The `build` command is used to build a SUSHI project. In SUSHI 2.x, it is the default command and can be used as follows:
 
 ```shell
-{{< terminal >}} sushi {fsh-project-directory} {options}
+{{< terminal >}} sushi build {fsh-project-directory} {options}
 ```
-
-{{% small-pageinfo color="primary" %}}
-<span class="tag">SUSHI 3.0</span>For SUSHI 3.0.0 and later, use the `build` command:
-
-```shell
-$ sushi build {fsh-project-directory} {options}
-```
-
-{{% /small-pageinfo %}}
 
 where options include the following (in any order):
 
 ```text
+-l, --log-level <level>  specify the level of log messages (default: "info") (choices: "error", "warn", "info", "debug")
 -o, --out <out>          the path to the output folder
--d, --debug              output extra debugging information
 -p, --preprocessed       output FSH produced by preprocessing steps
 -r, --require-latest     exit with error if this is not the latest version of SUSHI (default: false)
 -s, --snapshot           generate snapshot in Structure Definition output (default: false)
@@ -64,19 +47,8 @@ where options include the following (in any order):
 
 Further information about each option can be found in [Build Command Option Details](#build-command-option-details).
 
-{{% small-pageinfo color="primary" %}}
-<span class="tag">SUSHI 3.0</span> SUSHI 3.0 replaces the `-d, --debug` argument with a new argument that provides more control over log output:
-
-```
--l, --log-level <level>  specify the level of log messages (default: "info") (choices: "error", "warn", "info", "debug")
-```
-
-{{% /small-pageinfo %}}
-
 {{% alert title="Tip" color="success" %}}
-If you run SUSHI from your FSH project directory, and accept the defaults, the command can be shortened to `sushi .` or simply `sushi`.
-
-<span class="tag">SUSHI 3.0</span> For SUSHI 3.0, you can use `sushi build .` or `sushi build`.
+If you run SUSHI from your FSH project directory, and accept the defaults, the command can be shortened to `sushi build .` or simply `sushi build`.
 {{% /alert %}}
 
 #### `init`
@@ -84,25 +56,12 @@ If you run SUSHI from your FSH project directory, and accept the defaults, the c
 The `init` command is used to generate a project structure that is compatible with the FHIR IG Publisher. In SUSHI 2.x, it can be used as follows:
 
 ```shell
-{{< terminal >}} sushi --init
+{{< terminal >}} sushi init
 ```
-
-{{% small-pageinfo color="primary" %}}
-<span class="tag">SUSHI 3.0</span>For SUSHI 3.0.0 and later, use the `init` command:
-
-```shell
-$ sushi init
-```
-
-{{% /small-pageinfo %}}
 
 Further details on how to use this command can be found in [Initializing a SUSHI Project](/docs/sushi/project/#initializing-a-sushi-project).
 
 #### `update-dependencies`
-
-{{% small-pageinfo color="primary" %}}
-<span class="tag">SUSHI 3.0</span>The `update-dependencies` command is only available in SUSHI 3.0.0 and later.
-{{% /small-pageinfo %}}
 
 The `update-dependencies` command is used to update the FSH project's dependencies to the latest version. The command will check all dependencies defined in the `sushi-config.yaml` file to see if they are at the latest published version. SUSHI will output a list of all dependencies that have later versions and prompt the author whether to update. Choosing to update will directly modify the `sushi-config.yaml` file with the latest version and download the latest version of the dependency to the FHIR cache. Any dependency with a `current` or `dev` version will not be modified. This command can be used as follows:
 
@@ -281,7 +240,7 @@ SUSHI creates only the **fsh-generated** folder, but some of the files shown abo
 
 To run the IG Publisher, we recommend downloading the **\_updatePublisher.bat|sh** and **\_genonce.bat|sh** scripts provided by the sample-ig project. To get these scripts, [download the sample-ig project](https://github.com/FHIR/sample-ig/archive/master.zip), unzip it, and copy _all_ of the **.bat** and **.sh** files to the directory above the **fsh-generated** directory (**my-project** in the example above).
 
-If you used `sushi --init` (or `sushi init` for SUSHI 3.0) then these scripts were already downloaded and added to your project.
+If you used `sushi init` then these scripts were already downloaded and added to your project.
 
 ### Downloading the IG Publisher
 

--- a/content/docs/SUSHI/tips/_index.md
+++ b/content/docs/SUSHI/tips/_index.md
@@ -102,7 +102,7 @@ See the following documentation for additional details:
 
 The IG Publisher supports including instances of logical models as binary resources. This feature was announced and discussed in a [Logical Model Examples](https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/Logical.20Model.20Examples/near/251192344) thread on chat.fhir.org.
 
-Starting with SUSHI 3.0.0, authors can use `Instance:` to create instances of logical models and instances of logical model profiles in the same way as all other FSH instances. These instances are exported using standard JSON serialization and automatically receive `id` and `meta.profile` values when the logical model and SUSHI configuration support those elements. These instances have filenames starting with `Binary-` and will be auto-encoded as part of the publishing process.
+Authors can use `Instance:` to create instances of logical models and instances of logical model profiles in the same way as all other FSH instances. These instances are exported using standard JSON serialization and automatically receive `id` and `meta.profile` values when the logical model and SUSHI configuration support those elements. These instances have filenames starting with `Binary-` and will be auto-encoded as part of the publishing process.
 
 Alternatively, authors can provide their own instances of logical models without defining them in FSH. The basic steps an author needs to take in order to manually include logical model examples in a SUSHI project are:
 
@@ -155,11 +155,7 @@ If the logical model does not have `resourceType` or `id`, the same steps as abo
 
 ## Manual Slice Ordering
 
-{{% small-pageinfo color="primary" %}}
-<span class="tag">SUSHI 3.0</span>The manual slice ordering option is only available in SUSHI 3.0.0 and later.
-{{% /small-pageinfo %}}
-
-Starting in SUSHI `v3.0.0`, authors can exercise full manual control over the ordering of slice elements within Instances. Previous versions of SUSHI allowed for partial control of slice element ordering, but some ordering was determined by SUSHI's implementation and could not be affected by an author. In the current version of SUSHI (`v3.0.0` or later), authors can configure their FSH projects to manually control slice ordering. When using manual slice ordering, authors should use soft indexing and avoid using hard numeric indices.
+Authors can exercise full manual control over the ordering of slice elements within Instances. Previous versions of SUSHI allowed for partial control of slice element ordering, but some ordering was determined by SUSHI's implementation and could not be affected by an author. In the current version of SUSHI (`v3.0.0` or later), authors can configure their FSH projects to manually control slice ordering. When using manual slice ordering, authors should use soft indexing and avoid using hard numeric indices.
 
 Manual slice ordering follows the following rules:
 
@@ -237,10 +233,6 @@ InstanceOf: ExampleObservation
 This instance's `category` element will have four entries in the order specified: `laboratory`, `survey`, `exam`, `vital-signs`.
 
 ## Link References
-
-{{% small-pageinfo color="primary" %}}
-<span class="tag">SUSHI 3.0</span>Link references are only available in SUSHI 3.0.0 and later.
-{{% /small-pageinfo %}}
 
 SUSHI creates the **fsh-generated/includes/fsh-link-references.md** file to make it easier to create links to resource definitions in other markdown pages. This file's contents are a list of markdown link definitions, with one link for each resource in your **ImplementationGuide.json** file. This will include resources defined in FSH, the `resources` configuration property, and predefined resources. For example:
 ```markdown

--- a/content/docs/SUSHI/tutorial/_index.md
+++ b/content/docs/SUSHI/tutorial/_index.md
@@ -45,17 +45,8 @@ In addition, there are several files for building the IG.
 Now that you have SUSHI installed and a minimal FSH project, open up a command window, and navigate to the **FishExample** directory. Run SUSHI on those FSH files by executing:
 
 ```shell
-{{< terminal >}} sushi .
+{{< terminal >}} sushi build .
 ```
-
-{{% small-pageinfo color="primary" %}}
-<span class="tag">SUSHI 3.0</span>For SUSHI 3.0.0 and later, use the `build` command:
-
-```shell
-$ sushi build .
-```
-
-{{% /small-pageinfo %}}
 
 {{% alert title="Note" color="primary" %}}
 The dot (.) represents "this directory," the location of the FSH files. You can also specify the location explicitly by replacing the dot with a directory path.
@@ -157,7 +148,7 @@ Description: "The species of the fish."
 FSH ignores extra whitespace, so authors can choose to use whitespace for improved visual alignment, as in the extension definition above.
 {{% /alert %}}
 
-Run SUSHI again (`sushi .` or `sushi build .` for SUSHI 3.0). The count of Extensions should now be 1.
+Run SUSHI again (`sushi build .`). The count of Extensions should now be 1.
 
 ### Step 8: Define a Value Set for Fish Species
 

--- a/content/docs/goFSH/tutorial/_index.md
+++ b/content/docs/goFSH/tutorial/_index.md
@@ -44,7 +44,7 @@ Running GoFSH will create a **gofsh** directory, and populate it with **input/fs
 Now that you have generated FSH definitions, you can run SUSHI on those definitions to recreate your original input to GoFSH. First, ensure you have [SUSHI installed](/docs/sushi/installation). Then, navigate the command line to the **gofsh/** directory, and run:
 
 ```shell
-{{< terminal >}} sushi .
+{{< terminal >}} sushi build .
 ```
 
 This command will run SUSHI on the contents of **input/fsh**, and generate the output of that FSH into a directory called **fsh-generated/resources**. You can then compare the output from running GoFSH and then SUSHI to the original **StructureDefinition-mcode-genetic-specimen.json** and **StructureDefinition-mcode-laterality.json** files.


### PR DESCRIPTION
This PR removes the tags and boxes that called out features that were only available for SUSHI 3.0.0. Now that 3.0.0 has been available for almost a year, the documentation now assumes users are using at least that version and no longer specifically documents use for 2.x versions.

This PR also adds the new `-c, --config` option for the `build` command and the new prompt for Release Label for the `init` command.

_Note: This PR should not be merged until SUSHI 3.10.0 is ready to be released._